### PR TITLE
Fork to enable artifact promotions on Artifactory Pro

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.tw.go.plugins</groupId>
     <artifactId>go-artifactory-plugin</artifactId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <name>go-artifactory-plugin</name>

--- a/src/main/java/com/tw/go/plugins/artifactory/client/BuildMap.java
+++ b/src/main/java/com/tw/go/plugins/artifactory/client/BuildMap.java
@@ -14,6 +14,9 @@ import java.util.*;
 
 import static com.google.common.collect.Collections2.transform;
 import static com.google.common.collect.Lists.newArrayList;
+import static com.tw.go.plugins.artifactory.task.EnvironmentData.GO_PIPELINE_COUNTER;
+import static com.tw.go.plugins.artifactory.task.EnvironmentData.GO_STAGE_COUNTER;
+import static java.lang.String.format;
 import static org.jfrog.build.api.Build.STARTED_FORMAT;
 import static org.jfrog.build.api.BuildInfoProperties.BUILD_INFO_ENVIRONMENT_PREFIX;
 import static org.joda.time.format.DateTimeFormat.forPattern;
@@ -22,8 +25,9 @@ public class BuildMap implements Function<GoBuildDetails, Build> {
 
     @Override
     public Build apply(GoBuildDetails buildDetails) {
+        // Changed the id format for the usual default, with build info
         Module module = new ModuleBuilder()
-                .id(buildDetails.buildName())
+                .id(format("%s:%s", buildDetails.buildName(),buildDetails.buildNumber()))
                 .artifacts(artifactsFrom(buildDetails))
                 .build();
 

--- a/src/main/java/com/tw/go/plugins/artifactory/model/GoArtifactFactory.java
+++ b/src/main/java/com/tw/go/plugins/artifactory/model/GoArtifactFactory.java
@@ -1,29 +1,43 @@
 package com.tw.go.plugins.artifactory.model;
 
 import com.google.common.base.Function;
+import static com.google.common.collect.Collections2.transform;
+import com.thoughtworks.go.plugin.api.config.Property;
+import com.thoughtworks.go.plugin.api.task.EnvironmentVariables;
 import com.thoughtworks.go.plugin.api.task.TaskConfig;
 import com.thoughtworks.go.plugin.api.task.TaskExecutionContext;
-import com.tw.go.plugins.artifactory.task.config.UriConfig;
-import com.tw.go.plugins.artifactory.utils.filesystem.DirectoryScanner;
-
-import java.io.File;
-import java.util.Collection;
-import java.util.Map;
-
-import static com.google.common.collect.Collections2.transform;
+import static com.tw.go.plugins.artifactory.task.EnvironmentData.GO_PIPELINE_COUNTER;
+import static com.tw.go.plugins.artifactory.task.EnvironmentData.GO_PIPELINE_NAME;
+import static com.tw.go.plugins.artifactory.task.EnvironmentData.GO_STAGE_COUNTER;
 import static com.tw.go.plugins.artifactory.task.config.ConfigElement.buildProperties;
 import static com.tw.go.plugins.artifactory.task.config.ConfigElement.path;
 import static com.tw.go.plugins.artifactory.task.config.ConfigElement.uriConfig;
+import com.tw.go.plugins.artifactory.task.config.UriConfig;
+import com.tw.go.plugins.artifactory.utils.filesystem.DirectoryScanner;
+import java.io.File;
+import static java.lang.String.format;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Map.Entry;
 
 public class GoArtifactFactory {
 
     public Collection<GoArtifact> createArtifacts(final TaskConfig config, TaskExecutionContext context) {
         DirectoryScanner scanner = new DirectoryScanner(context.workingDir());
         Collection<File> files = scanner.scan(path.from(config));
-
-        return transform(files, goArtifact(uriConfig.from(config), buildProperties.from(config)));
+        
+        //Added default build properties to make Artifactory-Pro promotions work
+        Map<String, String> properties = new HashMap<>(buildProperties.from(config));
+        properties.put("build.name", GO_PIPELINE_NAME.from(context.environment()));
+        properties.put("build.number", buildNumber(context.environment()));
+        
+        return transform(files, goArtifact(uriConfig.from(config), properties));
     }
-
+    private String buildNumber(EnvironmentVariables envVars) {
+        return format("%s.%s", GO_PIPELINE_COUNTER.from(envVars), GO_STAGE_COUNTER.from(envVars));
+    }
+    
     private Function<File, GoArtifact> goArtifact(final UriConfig config, final Map<String, String> properties) {
         return new Function<File, GoArtifact>() {
             @Override

--- a/src/main/java/com/tw/go/plugins/artifactory/task/executor/PublishTaskExecutor.java
+++ b/src/main/java/com/tw/go/plugins/artifactory/task/executor/PublishTaskExecutor.java
@@ -33,6 +33,7 @@ public class PublishTaskExecutor implements TaskExecutor {
         Collection<GoArtifact> artifacts = artifactFactory.createArtifacts(config, context);
 
         EnvironmentVariables environment = context.environment();
+        
         GoBuildDetails details = buildDetailsFactory.createBuildDetails(environment, artifacts);
 
         try (ArtifactoryClient client = createClient(environment)) {

--- a/src/test/java/com/tw/go/plugins/artifactory/client/ArtifactoryClientTest.java
+++ b/src/test/java/com/tw/go/plugins/artifactory/client/ArtifactoryClientTest.java
@@ -113,7 +113,7 @@ public class ArtifactoryClientTest {
         ArgumentCaptor<Build> captor = ArgumentCaptor.forClass(Build.class);
         verify(buildInfoClient).sendBuildInfo(captor.capture());
 
-        Module module = new ModuleBuilder().id("buildName").addArtifact(
+        Module module = new ModuleBuilder().id("buildName:1.2").addArtifact(
                         new ArtifactBuilder("artifact.txt")
                                 .md5("9a0364b9e99bb480dd25e1f0284c8555")
                                 .sha1("040f06fd774092478d450774f5ba30c5da78acc8")

--- a/src/test/java/com/tw/go/plugins/artifactory/model/GoArtifactFactoryIntegrationTest.java
+++ b/src/test/java/com/tw/go/plugins/artifactory/model/GoArtifactFactoryIntegrationTest.java
@@ -10,26 +10,38 @@ import org.junit.Test;
 
 import java.io.File;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Map;
 
 import static com.tw.go.plugins.artifactory.testutils.FilesystemUtils.path;
+import static com.tw.go.plugins.artifactory.testutils.MapBuilder.map;
 import static org.apache.commons.lang.StringUtils.join;
 import static org.truth0.Truth.ASSERT;
 
 public class GoArtifactFactoryIntegrationTest {
+    
+    static private Map<String, String> envVars = map("GO_PIPELINE_NAME", "pipeline")
+            .and("GO_PIPELINE_COUNTER", "pipelineCounter")
+            .and("GO_STAGE_COUNTER", "stageCounter")
+            .and("GO_SERVER_URL", "https://localhost:8154/go/")
+            .and("ARTIFACTORY_PASSWORD", "passwd");
+
+            
     private static GoArtifactFactory factory;
     private static TaskExecutionContext context;
-    private Map<String, String> properties = ImmutableMap.<String, String>builder().put("name", "value").build();
+    private Map<String, String> properties = ImmutableMap.<String, String>builder().put("name", "value").put("build.name","pipeline").put("build.number","pipelineCounter.stageCounter").build();
 
     @BeforeClass
     public static void beforeAll() throws Exception {
+        
         context = new TaskExecutionContextBuilder()
                 .withWorkingDir(System.getProperty("user.dir"))
+                .withEnvVars(envVars)
                 .build();
+        
         factory = new GoArtifactFactory();
     }
 
+    
     @Test
     public void shouldCreateGoArtifacts() {
         TaskConfig config = new TaskConfigBuilder()


### PR DESCRIPTION
Hi,
We use Artifactory pro, and noticed that promotions that move artifacts to different methods didn't worked.
After some debugging we found that it was due to some missing properties in the artifact upload (build.name, and build.number)
I've made a small change to automatically add those properties on every upload.
