### PR TITLE
Allow environment variables in the uri

### DIFF
--- a/src/main/java/com/tw/go/plugins/artifactory/model/GoArtifactFactory.java
+++ b/src/main/java/com/tw/go/plugins/artifactory/model/GoArtifactFactory.java
@@ -37,7 +37,7 @@ public class GoArtifactFactory {
 
             private String artifactUri(String artifactName) {
                 String uri = config.isFolder() ? config.uri() + "/" + artifactName : config.uri();
-                StrSubstitutor sub = new StrSubstitutor(context.environment().asMap(), "${", "}");
+                StrSubstitutor sub = new StrSubstitutor(context.environment().asMap());
                 return sub.replace(uri);
             }
             

--- a/src/main/java/com/tw/go/plugins/artifactory/model/GoArtifactFactory.java
+++ b/src/main/java/com/tw/go/plugins/artifactory/model/GoArtifactFactory.java
@@ -1,30 +1,32 @@
 package com.tw.go.plugins.artifactory.model;
 
+import static com.google.common.collect.Collections2.transform;
+import static com.tw.go.plugins.artifactory.task.config.ConfigElement.buildProperties;
+import static com.tw.go.plugins.artifactory.task.config.ConfigElement.path;
+import static com.tw.go.plugins.artifactory.task.config.ConfigElement.uriConfig;
+
+import java.io.File;
+import java.util.Collection;
+import java.util.Map;
+
+import org.apache.commons.lang.text.StrSubstitutor;
+
 import com.google.common.base.Function;
 import com.thoughtworks.go.plugin.api.task.TaskConfig;
 import com.thoughtworks.go.plugin.api.task.TaskExecutionContext;
 import com.tw.go.plugins.artifactory.task.config.UriConfig;
 import com.tw.go.plugins.artifactory.utils.filesystem.DirectoryScanner;
 
-import java.io.File;
-import java.util.Collection;
-import java.util.Map;
-
-import static com.google.common.collect.Collections2.transform;
-import static com.tw.go.plugins.artifactory.task.config.ConfigElement.buildProperties;
-import static com.tw.go.plugins.artifactory.task.config.ConfigElement.path;
-import static com.tw.go.plugins.artifactory.task.config.ConfigElement.uriConfig;
-
 public class GoArtifactFactory {
 
     public Collection<GoArtifact> createArtifacts(final TaskConfig config, TaskExecutionContext context) {
         DirectoryScanner scanner = new DirectoryScanner(context.workingDir());
-        Collection<File> files = scanner.scan(path.from(config));
+        Collection<File> files = scanner.scan(path.from(config));        
 
-        return transform(files, goArtifact(uriConfig.from(config), buildProperties.from(config)));
+        return transform(files, goArtifact(uriConfig.from(config), buildProperties.from(config), context));
     }
 
-    private Function<File, GoArtifact> goArtifact(final UriConfig config, final Map<String, String> properties) {
+    private Function<File, GoArtifact> goArtifact(final UriConfig config, final Map<String, String> properties, final TaskExecutionContext context) {
         return new Function<File, GoArtifact>() {
             @Override
             public GoArtifact apply(File file) {
@@ -34,8 +36,11 @@ public class GoArtifactFactory {
             }
 
             private String artifactUri(String artifactName) {
-                return config.isFolder() ? config.uri() + "/" + artifactName : config.uri();
+                String uri = config.isFolder() ? config.uri() + "/" + artifactName : config.uri();
+                StrSubstitutor sub = new StrSubstitutor(context.environment().asMap(), "${", "}");
+                return sub.replace(uri);
             }
+            
         };
     }
 }

--- a/src/main/resources/view/publish.html
+++ b/src/main/resources/view/publish.html
@@ -5,7 +5,7 @@
 
     <label>Artifactory URI:<span class="asterisk">*</span></label>
     <input type="text" ng-model="URI" />
-    <div class="contextual_help has_go_tip_right" title="e.g. repo-key/path/to/artifact.ext or repo-key/dir"></div>
+    <div class="contextual_help has_go_tip_right" title="e.g. repo-key/path/to/artifact.ext or repo-key/dir. Env variables ${GO_REVISION}"></div>
     <span class="form_error" ng-show="GOINPUTNAME[URI].$error.server">{{ GOINPUTNAME[URI].$error.server }}</span>
 
     <div class="newline">


### PR DESCRIPTION
Fix for issue https://github.com/tusharm/go-artifactory-plugin/issues/18 

Allows the uri to contain go env variables and be substituted at run time
